### PR TITLE
Add a redirection to a Slack joining token link

### DIFF
--- a/join-slack/index.html
+++ b/join-slack/index.html
@@ -1,3 +1,4 @@
 ---
+# Can be regenerated in https://libero-community.slack.com using the invite users option in the menu. More info: https://get.slack.help/hc/en-us/articles/201330256-Invite-new-members-to-your-workspace#share-an-invite-link-
 redirect_to: "https://join.slack.com/t/libero-community/shared_invite/enQtNDc1MTUzMTM5MDQwLWE0YTZkYmVkMThhYWI1NTgzOWZkNjU2ZDgyNTRjZmJlZGRlOWFiYmNlZmE4MjZiMjRiNmM3ZDgzMmJjZjJhNjc"
 ---

--- a/join-slack/index.html
+++ b/join-slack/index.html
@@ -1,0 +1,3 @@
+---
+redirect_to: "https://join.slack.com/t/libero-community/shared_invite/enQtNDc1MTUzMTM5MDQwLWE0YTZkYmVkMThhYWI1NTgzOWZkNjU2ZDgyNTRjZmJlZGRlOWFiYmNlZmE4MjZiMjRiNmM3ZDgzMmJjZjJhNjc"
+---


### PR DESCRIPTION
You can't open up Slack for anyone to join but you can create links with an expiring token, and set the token expiration to "never". This gives us the ability to revoke the joining token but allow anyone to join. Keeping this in a single place will reduce overhead if we revoke and update the token, and gives us the ability to have a shorter link.